### PR TITLE
Add `enabled` prop to `KeyboardAvoidingView`

### DIFF
--- a/src/components/KeyboardAvoidingView.res
+++ b/src/components/KeyboardAvoidingView.res
@@ -6,10 +6,10 @@ type behavior = [#height | #position | #padding]
 external make: (
   ~ref: ref=?,
   // KeyboardAvoidingView props
-  ~enabled: bool=?,
-  ~keyboardVerticalOffset: float=?,
   ~behavior: behavior=?,
   ~contentContainerStyle: Style.t=?,
+  ~enabled: bool=?,
+  ~keyboardVerticalOffset: float=?,
   // rescript-react-native 0.64 || 0.65 || 0.66 View props
   ~accessibilityActions: array<Accessibility.actionInfo>=?,
   ~accessibilityElementsHidden: bool=?,

--- a/src/components/KeyboardAvoidingView.res
+++ b/src/components/KeyboardAvoidingView.res
@@ -6,6 +6,7 @@ type behavior = [#height | #position | #padding]
 external make: (
   ~ref: ref=?,
   // KeyboardAvoidingView props
+  ~enabled: bool=?,
   ~keyboardVerticalOffset: float=?,
   ~behavior: behavior=?,
   ~contentContainerStyle: Style.t=?,


### PR DESCRIPTION
Hello 👋,
Thanks for this pretty extensive binding. I just noticed that the [`enabled` prop of `KeyboardAvoidingView`](https://reactnative.dev/docs/keyboardavoidingview#enabled) was missing so I decided to add it.