### PR TITLE
Do not use optional fields in callback params

### DIFF
--- a/src/apis/Share.res
+++ b/src/apis/Share.res
@@ -31,9 +31,11 @@ external sharedAction: action = "sharedAction"
 @module("react-native") @scope("Share")
 external dismissedAction: action = "dismissedAction"
 
+// This is usually only used as a callback param and not created by the user.
+// Therefore prefer option<...> to an optional field for easier matching.
 type shareResult = {
   action: action,
-  activityType?: string,
+  activityType: option<string>,
 }
 
 // multiple externals

--- a/src/components/Pressable.res
+++ b/src/components/Pressable.res
@@ -16,11 +16,13 @@ external rippleConfig: (
   unit,
 ) => rippleConfig = ""
 
+// This is usually only used as a callback param and not created by the user.
+// Therefore prefer option<...> to an optional field for easier matching.
 type interactionState = {
   pressed: bool,
   // React Native Web
-  hovered?: bool,
-  focused?: bool,
+  hovered: option<bool>,
+  focused: option<bool>,
 }
 
 @react.component @module("react-native")


### PR DESCRIPTION
Optional fields are weird to match on because of https://rescript-lang.org/docs/manual/latest/record#pattern-matching-on-optional-fields:

![interactionState](https://user-images.githubusercontent.com/591384/199210984-9b738ca0-1f6b-49d6-8188-2f973e5c1291.png)

Therefore do not use them for callback params, only for user-created records.