### PR TITLE
Add Style.empty

### DIFF
--- a/src/apis/Style.bs.js
+++ b/src/apis/Style.bs.js
@@ -15,8 +15,11 @@ function rad(num) {
 
 var FontWeight = {};
 
+var empty = {};
+
 exports.pct = pct;
 exports.deg = deg;
 exports.rad = rad;
 exports.FontWeight = FontWeight;
+exports.empty = empty;
 /* No side effect */

--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -741,3 +741,5 @@ external imageStyle: (
   ~zIndex: int=?,
   unit,
 ) => t = ""
+
+let empty: t = style()

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -736,3 +736,5 @@ external imageStyle: (
   ~zIndex: int=?,
   unit,
 ) => t = ""
+
+let empty: t


### PR DESCRIPTION
This is nice to avoid options / `Style.arrayOption`, as in

```rescript
Style.array([style1, condition ? style2 : Style.empty])
```