### PR TITLE
Platform: Add doc comment to prevent user from using switch

### DIFF
--- a/src/apis/Platform.res
+++ b/src/apis/Platform.res
@@ -1,3 +1,15 @@
 type os = [#ios | #android | #macos | #windows | #web]
 
-@module("react-native") @scope("Platform") external os: os = "OS"
+/** Do not switch on `Platform.os`, as it will result in code
+that prevents the Metro bundler from inlining. Instead, use an if 
+or ternary expression. 
+
+```rescript
+Platform.os === #ios 
+  ? doSomethingInIos() 
+  : doSomethingInOtherPlatform()
+```
+*/
+@module("react-native")
+@scope("Platform")
+external os: os = "OS"


### PR DESCRIPTION
While we cannot prevent the user to use a switch on `Platform.os` which prevents Metro bundler from inlining, we totally can at least mention it in the editor tooltips. 

<img width="792" alt="image" src="https://user-images.githubusercontent.com/18074327/199485294-853c9b38-70ef-446b-b768-086394c05ccf.png">

