### PR TITLE
Add missing TextInput.textAlign and textAlignVertical

### DIFF
--- a/src/components/TextInput.res
+++ b/src/components/TextInput.res
@@ -269,6 +269,8 @@ external make: (
   ~selectTextOnFocus: bool=?,
   ~showSoftInputOnFocus: bool=?,
   ~spellCheck: bool=?,
+  ~textAlign: [#left | #center | #right]=?,
+  ~textAlignVertical: Style.textAlignVertical=?,
   ~textBreakStrategy: textBreakStrategy=?,
   ~textContentType: textContentType=?,
   ~underlineColorAndroid: Color.t=?,


### PR DESCRIPTION
Just needed textAlignVertical to set multiline TextInput vertical alignment on Android, and it turns out that the text alignment props are missing from TextInput.

(Note that, for textAlign, there are fewer option than in `Style.textAlign`.)