### PR TITLE
add lineBreakStrategyIOS Props for Text component

### DIFF
--- a/src/components/Text.res
+++ b/src/components/Text.res
@@ -18,6 +18,8 @@ type ellipsizeMode = [#clip | #head | #middle | #tail]
 
 type textBreakStrategy = [#simple | #highQuality | #balanced]
 
+type lineBreakStrategyIOS = [#none | #standard | #"hangul-word" | #"push-out"]
+
 @react.component @module("react-native")
 external make: (
   ~ref: ref=?,
@@ -37,6 +39,7 @@ external make: (
   ~dataDetectorTypes: array<dataDetectorType>=?,
   ~disabled: bool=?,
   ~ellipsizeMode: ellipsizeMode=?,
+  ~lineBreakStrategyIOS: lineBreakStrategyIOS=?,
   ~maxFontSizeMultiplier: int=?,
   ~minimumFontScale: float=?,
   ~nativeID: string=?,


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/rescript-react-native/.github/blob/master/CONTRIBUTING.md

-->
Thanks for the good bindings here.
We are developing in a region where Korean text is used. We need this prop for line breaking. 

Closes #<number-of-the-issue>

<!--
Add any information that might be useful
-->
