### PR TITLE
add one-time-code to textinput autoComplete

### DIFF
--- a/src/components/TextInput.res
+++ b/src/components/TextInput.res
@@ -131,6 +131,7 @@ type autoComplete = [
   | #password
   | #tel
   | #username
+  | #"one-time-code"
 ]
 
 type t


### PR DESCRIPTION
Thank you for this project.  I added it to use `one-time-code`.

> https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Components/TextInput/TextInput.js#L258