### PR TITLE
Add dataDetectorTypes at textinput

### DIFF
--- a/src/components/TextInput.res
+++ b/src/components/TextInput.res
@@ -217,6 +217,8 @@ type textContentType = [
   | #oneTimeCode
 ]
 
+type dataDetectorTypes = [#phoneNumber | #link | #address | #calendarEvent | #none | #all]
+
 @react.component @module("react-native")
 external make: (
   ~ref: ref=?,
@@ -233,7 +235,7 @@ external make: (
   ~contextMenuHidden: bool=?,
   ~defaultValue: string=?,
   ~disableFullscreenUI: bool=?,
-  ~dataDetectorTypes: [#phoneNumber | #link | #address | #calendarEvent | #none | #all]=?,
+  ~dataDetectorTypes: array<dataDetectorTypes>=?,
   ~editable: bool=?,
   ~enablesReturnKeyAutomatically: bool=?,
   ~importantForAutofill: importantForAutofill=?,

--- a/src/components/TextInput.res
+++ b/src/components/TextInput.res
@@ -233,7 +233,7 @@ external make: (
   ~contextMenuHidden: bool=?,
   ~defaultValue: string=?,
   ~disableFullscreenUI: bool=?,
-  ~dataDetectorTypes: array<Text.dataDetectorTypes>=?,
+  ~dataDetectorTypes: array<Text.dataDetectorType>=?,
   ~editable: bool=?,
   ~enablesReturnKeyAutomatically: bool=?,
   ~importantForAutofill: importantForAutofill=?,

--- a/src/components/TextInput.res
+++ b/src/components/TextInput.res
@@ -217,8 +217,6 @@ type textContentType = [
   | #oneTimeCode
 ]
 
-type dataDetectorTypes = [#phoneNumber | #link | #address | #calendarEvent | #none | #all]
-
 @react.component @module("react-native")
 external make: (
   ~ref: ref=?,
@@ -235,7 +233,7 @@ external make: (
   ~contextMenuHidden: bool=?,
   ~defaultValue: string=?,
   ~disableFullscreenUI: bool=?,
-  ~dataDetectorTypes: array<dataDetectorTypes>=?,
+  ~dataDetectorTypes: array<Text.dataDetectorTypes>=?,
   ~editable: bool=?,
   ~enablesReturnKeyAutomatically: bool=?,
   ~importantForAutofill: importantForAutofill=?,

--- a/src/components/TextInput.res
+++ b/src/components/TextInput.res
@@ -233,6 +233,7 @@ external make: (
   ~contextMenuHidden: bool=?,
   ~defaultValue: string=?,
   ~disableFullscreenUI: bool=?,
+  ~dataDetectorTypes: [#phoneNumber | #link | #address | #calendarEvent | #none | #all]=?,
   ~editable: bool=?,
   ~enablesReturnKeyAutomatically: bool=?,
   ~importantForAutofill: importantForAutofill=?,


### PR DESCRIPTION
A PR that adds dataDetectorTypes to textInput.

[dataDetectorTypes](https://reactnative.dev/docs/textinput#datadetectortypes-ios)