### PR TITLE
Remove obsolete j` string interpolation

### DIFF
--- a/src/apis/Color.bs.js
+++ b/src/apis/Color.bs.js
@@ -2,19 +2,19 @@
 
 
 function rgb(r, g, b) {
-  return "rgb(" + r + ", " + g + ", " + b + ")";
+  return "rgb(" + r.toString() + ", " + g.toString() + ", " + b.toString() + ")";
 }
 
 function rgba(r, g, b, a) {
-  return "rgba(" + r + ", " + g + ", " + b + ", " + a + ")";
+  return "rgba(" + r.toString() + ", " + g.toString() + ", " + b.toString() + ", " + a.toString() + ")";
 }
 
 function hsl(h, s, l) {
-  return "hsl(" + h + ", " + s + "%, " + l + "%)";
+  return "hsl(" + h.toString() + ", " + s.toString() + "%, " + l.toString() + "%)";
 }
 
 function hsla(h, s, l, a) {
-  return "hsl(" + h + ", " + s + "%, " + l + "%, " + a + ")";
+  return "hsl(" + h.toString() + ", " + s.toString() + "%, " + l.toString() + "%, " + a.toString() + ")";
 }
 
 exports.rgb = rgb;

--- a/src/apis/Color.res
+++ b/src/apis/Color.res
@@ -3,11 +3,15 @@ type t = string
 @module("react-native")
 external processColor: string => string = "processColor"
 
-let rgb = (~r: int, ~g: int, ~b: int) => j`rgb($r, $g, $b)`
-let rgba = (~r: int, ~g: int, ~b: int, ~a: float) => j`rgba($r, $g, $b, $a)`
+let rgb = (~r: int, ~g: int, ~b: int) =>
+  `rgb(${r->Js.Int.toString}, ${g->Js.Int.toString}, ${b->Js.Int.toString})`
+let rgba = (~r: int, ~g: int, ~b: int, ~a: float) =>
+  `rgba(${r->Js.Int.toString}, ${g->Js.Int.toString}, ${b->Js.Int.toString}, ${a->Js.Float.toString})`
 
-let hsl = (~h: float, ~s: float, ~l: float) => j`hsl($h, $s%, $l%)`
-let hsla = (~h: float, ~s: float, ~l: float, ~a: float) => j`hsl($h, $s%, $l%, $a)`
+let hsl = (~h: float, ~s: float, ~l: float) =>
+  `hsl(${h->Js.Float.toString}, ${s->Js.Float.toString}%, ${l->Js.Float.toString}%)`
+let hsla = (~h: float, ~s: float, ~l: float, ~a: float) =>
+  `hsl(${h->Js.Float.toString}, ${s->Js.Float.toString}%, ${l->Js.Float.toString}%, ${a->Js.Float.toString})`
 
 @inline
 let transparent = "transparent"


### PR DESCRIPTION
Template strings with
```
j`
```
are deprecated in 10.1.4 and will be removed in 11.0.