### PR TITLE
Add FlatList method - scrollToIndex

### DIFF
--- a/src/components/FlatList.res
+++ b/src/components/FlatList.res
@@ -151,3 +151,13 @@ external make: (
   ~onMouseOut: ReactEvent.Mouse.t => unit=?,
   ~onMouseUp: ReactEvent.Mouse.t => unit=?,
 ) => React.element = "FlatList"
+
+type params = {
+  index?: int,
+  animated?: bool,
+  viewOffset?: float,
+  viewPosition?: float,
+}
+
+@send
+external scrollToIndex: (element, params) => unit = "scrollToIndex"


### PR DESCRIPTION
Hi! Thanks for the great React Native binding.

I added a scrollToIndex method in FlatList.

Thanks!