### PR TITLE
change onPress signature

### DIFF
--- a/src/apis/Alert.res
+++ b/src/apis/Alert.res
@@ -11,7 +11,7 @@ type style = [#default | #cancel | #destructive]
 
 type button = {
   text?: string,
-  onPress?: unit => unit,
+  onPress?: option<string> => unit,
   style?: style,
   isPreferred?: bool,
 }


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/rescript-react-native/.github/blob/master/CONTRIBUTING.md

-->

Closes #<number-of-the-issue>

<!--
Add any information that might be useful
-->

The exact signature for onPress looks like this.
```res
onPress?: option<string> => unit
```
https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Alert/Alert.d.ts#L15