### PR TITLE
Fix fontWeight again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog of `rescript-react-native`
 
+## Next
+
+- BREAKING: Fix `fontWeight` type again. https://github.com/rescript-react-native/rescript-react-native/pull/806
+
 ## 0.72.0 - 2023-08-04
 
 - Remove deprecated Slider, DatePickerIOS & ProgressViewIOS [82dc6e1](https://github.com/rescript-react-native/rescript-react-native/commit/82dc6e1) by [@MoOx](https://github.com/MoOx)

--- a/src/apis/Style.bs.js
+++ b/src/apis/Style.bs.js
@@ -13,10 +13,13 @@ function rad(num) {
   return num.toString() + "rad";
 }
 
+var FontWeight = {};
+
 var empty = {};
 
 exports.pct = pct;
 exports.deg = deg;
 exports.rad = rad;
+exports.FontWeight = FontWeight;
 exports.empty = empty;
 /* No side effect */

--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -50,7 +50,36 @@ type resizeMode = [#cover | #contain | #stretch | #repeat | #center]
 
 type fontStyle = [#normal | #italic]
 
-type fontWeight = [#normal | #bold | #100 | #200 | #300 | #400 | #500 | #600 | #700 | #800 | #900]
+module FontWeight = {
+  // Note: we cannot model this as a polymorphic variant
+  // because #"100" = #100 = the number 100 in JS, but we need the string "100" here.
+  type t = string
+
+  @inline
+  let normal = "normal"
+  @inline
+  let bold = "bold"
+  @inline
+  let _100 = "100"
+  @inline
+  let _200 = "200"
+  @inline
+  let _300 = "300"
+  @inline
+  let _400 = "400"
+  @inline
+  let _500 = "500"
+  @inline
+  let _600 = "600"
+  @inline
+  let _700 = "700"
+  @inline
+  let _800 = "800"
+  @inline
+  let _900 = "900"
+}
+
+type fontWeight = FontWeight.t
 
 // @todo in 0.71.0
 // Apparently there are more `fontVariant` options IOS specific

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -45,8 +45,36 @@ type resizeMode = [#cover | #contain | #stretch | #repeat | #center]
 
 type fontStyle = [#normal | #italic]
 
-type fontWeight = [#normal | #bold | #100 | #200 | #300 | #400 | #500 | #600 | #700 | #800 | #900]
+module FontWeight: {
+  // Note: we cannot model this as a polymorphic variant
+  // because #"100" = #100 = the number 100 in JS, but we need the string "100" here.
+  type t
 
+  @inline("normal")
+  let normal: t
+  @inline("bold")
+  let bold: t
+  @inline("100")
+  let _100: t
+  @inline("200")
+  let _200: t
+  @inline("300")
+  let _300: t
+  @inline("400")
+  let _400: t
+  @inline("500")
+  let _500: t
+  @inline("600")
+  let _600: t
+  @inline("700")
+  let _700: t
+  @inline("800")
+  let _800: t
+  @inline("900")
+  let _900: t
+}
+
+type fontWeight = FontWeight.t
 type fontVariant = [
   | #"small-caps"
   | #"oldstyle-nums"


### PR DESCRIPTION
Fixes #775 again by reverting the `fontWeight` type definition to its pre-#793 state.

Unfortunately this is a breaking change yet again. But better than crashes on Android...