### PR TITLE
Fix transform origin

### DIFF
--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -47,13 +47,20 @@ type transform
 external unsafeTransform: Js.t<'a> => transform = "%identity"
 
 @unboxed
-type transformOrigin =
-  | @as("top") Top
-  | @as("bottom") Bottom
+type transformOriginX =
   | @as("left") Left
   | @as("right") Right
   | @as("center") Center
   | Size(size)
+
+@unboxed
+type transformOriginY =
+  | @as("top") Top
+  | @as("bottom") Bottom
+  | @as("center") Center
+  | Size(size)
+
+type transformOrigin = (transformOriginX, transformOriginY, float)
 
 type resizeMode = [#cover | #contain | #stretch | #repeat | #center]
 
@@ -255,7 +262,7 @@ type shadowIOSStyle = {
 // Transform Props (https://reactnative.dev/docs/transforms#props)
 type transformStyle = {
   transform?: array<transform>,
-  transformOrigin?: array<transformOrigin>,
+  transformOrigin?: transformOrigin,
 }
 
 // View styles https://reactnative.dev/docs/view-style-props

--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -48,16 +48,16 @@ external unsafeTransform: Js.t<'a> => transform = "%identity"
 
 @unboxed
 type transformOriginX =
-  | @as("left") Left
-  | @as("right") Right
-  | @as("center") Center
+  | @as("0%") Left
+  | @as("100%") Right
+  | @as("50%") Center
   | Size(size)
 
 @unboxed
 type transformOriginY =
-  | @as("top") Top
-  | @as("bottom") Bottom
-  | @as("center") Center
+  | @as("0%") Top
+  | @as("100%") Bottom
+  | @as("50%") Center
   | Size(size)
 
 type transformOrigin = (transformOriginX, transformOriginY, float)

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -43,16 +43,16 @@ external unsafeTransform: Js.t<'a> => transform = "%identity"
 
 @unboxed
 type transformOriginX =
-  | @as("left") Left
-  | @as("right") Right
-  | @as("center") Center
+  | @as("0%") Left
+  | @as("100%") Right
+  | @as("50%") Center
   | Size(size)
 
 @unboxed
 type transformOriginY =
-  | @as("top") Top
-  | @as("bottom") Bottom
-  | @as("center") Center
+  | @as("0%") Top
+  | @as("100%") Bottom
+  | @as("50%") Center
   | Size(size)
 
 type transformOrigin = (transformOriginX, transformOriginY, float)

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -42,13 +42,20 @@ type transform
 external unsafeTransform: Js.t<'a> => transform = "%identity"
 
 @unboxed
-type transformOrigin =
-  | @as("top") Top
-  | @as("bottom") Bottom
+type transformOriginX =
   | @as("left") Left
   | @as("right") Right
   | @as("center") Center
   | Size(size)
+
+@unboxed
+type transformOriginY =
+  | @as("top") Top
+  | @as("bottom") Bottom
+  | @as("center") Center
+  | Size(size)
+
+type transformOrigin = (transformOriginX, transformOriginY, float)
 
 type resizeMode = [#cover | #contain | #stretch | #repeat | #center]
 
@@ -243,7 +250,7 @@ type shadowIOSStyle = {
 // Transform Props (https://reactnative.dev/docs/transforms#props)
 type transformStyle = {
   transform?: array<transform>,
-  transformOrigin?: array<transformOrigin>,
+  transformOrigin?: transformOrigin,
 }
 
 // View styles https://reactnative.dev/docs/view-style-props


### PR DESCRIPTION
The typescript type on `transformOrigin` is very weak

```
  transformOrigin?: Array<string | number> | string | undefined;
```
https://github.com/facebook/react-native/blob/4165884b700341ba549ed8385480fd98128e7bb1/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts#L296


Compare to the `processTransformOrigin` function that analyse the transformOrigin value on DEV mode
https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/StyleSheet/processTransformOrigin.js