### PR TITLE
Get rid of Js.t

### DIFF
--- a/src/apis/Global.res
+++ b/src/apis/Global.res
@@ -1,4 +1,4 @@
 @val external __DEV__: bool = "__DEV__"
 
 @scope("global") @val
-external hermesInternal: option<Js.t<'a>> = "HermesInternal"
+external hermesInternal: option<{..}> = "HermesInternal"

--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -7,9 +7,9 @@ external arrayOption: array<option<t>> => t = "%identity"
 // Useful if you play with fancy platforms
 // Use with caution
 @val
-external unsafeAddStyle: (@as(json`{}`) _, t, Js.t<'a>) => t = "Object.assign"
+external unsafeAddStyle: (@as(json`{}`) _, t, {..}) => t = "Object.assign"
 
-external unsafeStyle: Js.t<'a> => t = "%identity"
+external unsafeStyle: {..} => t = "%identity"
 
 type size = string
 
@@ -44,7 +44,7 @@ type transform
 @obj external skewY: (~skewY: angle) => transform = ""
 // @todo matrix
 
-external unsafeTransform: Js.t<'a> => transform = "%identity"
+external unsafeTransform: {..} => transform = "%identity"
 
 @unboxed
 type transformOriginX =

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -3,8 +3,8 @@ type t
 external array: array<t> => t = "%identity"
 external arrayOption: array<option<t>> => t = "%identity"
 @val
-external unsafeAddStyle: (@as(json`{}`) _, t, Js.t<'a>) => t = "Object.assign"
-external unsafeStyle: Js.t<'a> => t = "%identity"
+external unsafeAddStyle: (@as(json`{}`) _, t, {..}) => t = "Object.assign"
+external unsafeStyle: {..} => t = "%identity"
 
 type size
 
@@ -39,7 +39,7 @@ type transform
 @obj external skewY: (~skewY: angle) => transform = ""
 // @todo matrix
 
-external unsafeTransform: Js.t<'a> => transform = "%identity"
+external unsafeTransform: {..} => transform = "%identity"
 
 @unboxed
 type transformOriginX =

--- a/src/apis/StyleSheet.res
+++ b/src/apis/StyleSheet.res
@@ -6,6 +6,6 @@ external absoluteFill: Style.t = "absoluteFill"
 external absoluteFillObject: Style.t = "absoluteFillObject"
 
 @module("react-native") @scope("StyleSheet")
-external create: Js.t<'a> => Js.t<'a> = "create"
+external create: ({..} as 'a) => ({..} as 'a) = "create"
 @module("react-native") @scope("StyleSheet")
 external flatten: array<Style.t> => Style.t = "flatten"

--- a/src/components/SectionList.res
+++ b/src/components/SectionList.res
@@ -6,7 +6,7 @@ external flashScrollIndicators: element => unit = "flashScrollIndicators"
 @send external recordInteraction: element => unit = "recordInteraction"
 
 @send
-external setNativeProps: (element, Js.t<'a>) => unit = "setNativeProps"
+external setNativeProps: (element, {..}) => unit = "setNativeProps"
 
 type props<'sectionData, 'item, 'extraData> = {
   ref?: ref,

--- a/src/elements/NativeMethods.res
+++ b/src/elements/NativeMethods.res
@@ -9,7 +9,7 @@ module Make = (
   external findNodeHandle: T.t => nodeHandle = "findNodeHandle"
 
   @send
-  external setNativeProps: (T.t, Js.t<'a>) => unit = "setNativeProps"
+  external setNativeProps: (T.t, {..}) => unit = "setNativeProps"
 
   @send external focus: T.t => unit = "focus"
   @send external blur: T.t => unit = "blur"

--- a/src/elements/ScrollViewMethods.res
+++ b/src/elements/ScrollViewMethods.res
@@ -20,5 +20,5 @@ module Make = (
   external flashScrollIndicators: T.t => unit = "flashScrollIndicators"
 
   @send
-  external setNativeProps: (T.t, Js.t<'a>) => unit = "setNativeProps"
+  external setNativeProps: (T.t, {..}) => unit = "setNativeProps"
 }


### PR DESCRIPTION
Last PR in my "kill `Js` namespace" series.
(Without moving to Core or ReScript 12, we cannot do `Js.Nullable.t` -> `nullable` etc.)