### PR TITLE
deprecate other @obj

### DIFF
--- a/src/apis/Animated.res
+++ b/src/apis/Animated.res
@@ -207,9 +207,9 @@ external parallel: (array<Animation.t>, parallelPayload) => Animation.t = "paral
 @module("react-native") @scope("Animated")
 external stagger: (float, array<Animation.t>) => Animation.t = "stagger"
 
-type loopConfig
-
-@obj external loopConfig: (~iterations: int) => loopConfig = ""
+type loopConfig = {iterations?: int, resetBeforeIteration?: bool}
+@deprecated("Directly create record instead") @obj
+external loopConfig: (~iterations: int=?, ~resetBeforeIteration: bool=?) => loopConfig = ""
 
 // multiple externals
 @module("react-native") @scope("Animated")

--- a/src/apis/AppRegistry.res
+++ b/src/apis/AppRegistry.res
@@ -15,16 +15,20 @@ type appParameters
 
 external asAppParameters: 'a => appParameters = "%identity"
 
-type appConfig
-
-@obj
+type appConfig<'a> = {
+  appKey: string,
+  component?: componentProvider<'a>,
+  run?: appParameters => unit,
+  section?: bool,
+}
+@deprecated("Directly create record instead") @obj
 external appConfig: (
   ~appKey: string,
   ~component: componentProvider<'a>=?,
   ~run: appParameters => unit=?,
   ~section: bool=?,
   unit,
-) => appConfig = ""
+) => appConfig<'a> = ""
 
 type runnable<'a> = {
   "component": Js.Nullable.t<componentProvider<'a>>,
@@ -62,7 +66,7 @@ external registerComponentWithSection: (appKey, componentProvider<'a>, section) 
   "registerComponent"
 
 @module("react-native") @scope("AppRegistry")
-external registerConfig: array<appConfig> => unit = "registerConfig"
+external registerConfig: array<appConfig<'a>> => unit = "registerConfig"
 
 @module("react-native") @scope("AppRegistry")
 external registerRunnable: (appKey, appParameters => unit) => string = "registerRunnable"

--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -22,8 +22,12 @@ type margin = size
 @inline
 let auto = "auto"
 
-type offset
-@obj external offset: (~height: float, ~width: float) => offset = ""
+type offset = {
+  height: float,
+  width: float,
+}
+@deprecated("Directly create record instead") @obj
+external offset: (~height: float, ~width: float) => offset = ""
 
 type angle
 let deg: float => angle = num => (num->Js.Float.toString ++ "deg")->Obj.magic

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -17,8 +17,12 @@ type margin = size
 @inline("auto")
 let auto: margin
 
-type offset
-@obj external offset: (~height: float, ~width: float) => offset = ""
+type offset = {
+  height: float,
+  width: float,
+}
+@deprecated("Directly create record instead") @obj
+external offset: (~height: float, ~width: float) => offset = ""
 
 type angle
 let deg: float => angle

--- a/src/components/ScrollView.res
+++ b/src/components/ScrollView.res
@@ -1,7 +1,8 @@
 include ScrollViewElement
 
-type contentOffset
-@obj external contentOffset: (~x: float, ~y: float) => contentOffset = ""
+type contentOffset = {x: float, y: float}
+@deprecated("Directly create record instead") @obj
+external contentOffset: (~x: float, ~y: float) => contentOffset = ""
 
 type contentInsetAdjustmentBehavior = [
   | #automatic


### PR DESCRIPTION
I deprecate some missing `@obj` on the project but I can't decide what to do with some of them.


Example with `transform`

```rescript
type transform
@obj external perspective: (~perspective: float) => transform = ""
@obj external rotate: (~rotate: angle) => transform = ""
@obj external rotateX: (~rotateX: angle) => transform = ""
@obj external rotateY: (~rotateY: angle) => transform = ""
@obj external rotateZ: (~rotateZ: angle) => transform = ""
@obj external scale: (~scale: float) => transform = ""
@obj external scaleX: (~scaleX: float) => transform = ""
@obj external scaleY: (~scaleY: float) => transform = ""
@obj external translateX: (~translateX: size) => transform = ""
@obj external translateY: (~translateY: size) => transform = ""
@obj external skewX: (~skewX: angle) => transform = ""
@obj external skewY: (~skewY: angle) => transform = ""
```

In the react-native doc it's:

> array of objects: `{matrix: number[]}`, `{perspective: number}`,`{rotate: string}`, `{rotateX: string}`, `{rotateY: string}`, `{rotateZ: string}`, `{scale: number}`, `{scaleX: number}`, `{scaleY: number}`, `{translateX: number}`, `{translateY: number}`, `{skewX: string}`, `{skewY: string}` or string

We cannot type it with `@unboxed` so I only see two strategies:

1. Record with optional fields
```rescript
type transform = {
  rotate?: angle,
  scale?: float,
  translateX?: float,
  …
}
```
Pro: JS output is clean and  easy to write
Con: Can be error prone

2. Variant
```rescript
type transform2 =
  | Rotate({rotate: angle})
  | Scale({scale: float})
  | TranslateX({translateX: float})
```
Pro: Enforce type
Con: JS output an object with a `TAG` field (even if we can cutomize it with `@tag`)

What's your opinion on it @cknitt ?