### PR TITLE
0.77 changes

### DIFF
--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -96,6 +96,27 @@ type filter
 
 external unsafeFilter: {..} => filter = "%identity"
 
+type blendMode = [
+  | #normal
+  | #multiply
+  | #screen
+  | #overlay
+  | #darken
+  | #lighten
+  | #"color-dodge"
+  | #"color-burn"
+  | #"hard-light"
+  | #"soft-light"
+  | #difference
+  | #exclusion
+  | #hue
+  | #saturation
+  | #color
+  | #luminosity
+]
+
+type isolation = [#auto | #isolate]
+
 type resizeMode = [#cover | #contain | #stretch | #repeat | #center]
 
 type fontStyle = [#normal | #italic]
@@ -333,6 +354,8 @@ type viewCoreStyle = {
   borderTopStartRadius?: float,
   boxShadow?: array<boxShadow>,
   filter?: array<filter>,
+  mixBlendMode?: blendMode,
+  isolation?: isolation,
   elevation?: float,
   opacity?: float,
 }

--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -138,7 +138,7 @@ type backfaceVisibility = [#visible | #hidden]
 
 type borderStyle = [#solid | #dotted | #dashed]
 
-type display = [#none | #flex]
+type display = [#none | #flex | #contents]
 
 type overflow = [#visible | #hidden | #scroll]
 

--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -117,6 +117,8 @@ type blendMode = [
 
 type isolation = [#auto | #isolate]
 
+type outlineStyle = [#solid | #dotted | #dashed]
+
 type resizeMode = [#cover | #contain | #stretch | #repeat | #center]
 
 type fontStyle = [#normal | #italic]
@@ -358,6 +360,10 @@ type viewCoreStyle = {
   isolation?: isolation,
   elevation?: float,
   opacity?: float,
+  outlineColor?: Color.t,
+  outlineOffset?: float,
+  outlineStyle?: outlineStyle,
+  outlineWidth?: float,
 }
 
 // Text Style Props (https://reactnative.dev/docs/text-style-props)

--- a/src/apis/Style.res
+++ b/src/apis/Style.res
@@ -140,6 +140,8 @@ type borderStyle = [#solid | #dotted | #dashed]
 
 type display = [#none | #flex | #contents]
 
+type boxSizing = [#"border-box" | #"content-box"]
+
 type overflow = [#visible | #hidden | #scroll]
 
 type flexWrap = [#wrap | #nowrap]
@@ -230,6 +232,7 @@ type flexStyle = {
   columnGap?: size,
   direction?: direction,
   display?: display,
+  boxSizing?: boxSizing,
   end?: size,
   flex?: float,
   flexBasis?: margin,

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -91,6 +91,27 @@ type filter
 
 external unsafeFilter: {..} => filter = "%identity"
 
+type blendMode = [
+  | #normal
+  | #multiply
+  | #screen
+  | #overlay
+  | #darken
+  | #lighten
+  | #"color-dodge"
+  | #"color-burn"
+  | #"hard-light"
+  | #"soft-light"
+  | #difference
+  | #exclusion
+  | #hue
+  | #saturation
+  | #color
+  | #luminosity
+]
+
+type isolation = [#auto | #isolate]
+
 type resizeMode = [#cover | #contain | #stretch | #repeat | #center]
 
 type fontStyle = [#normal | #italic]
@@ -321,6 +342,8 @@ type viewCoreStyle = {
   borderTopStartRadius?: float,
   boxShadow?: array<boxShadow>,
   filter?: array<filter>,
+  mixBlendMode?: blendMode,
+  isolation?: isolation,
   elevation?: float,
   opacity?: float,
 }

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -128,6 +128,8 @@ type borderStyle = [#solid | #dotted | #dashed]
 
 type display = [#none | #flex | #contents]
 
+type boxSizing = [#"border-box" | #"content-box"]
+
 type overflow = [#visible | #hidden | #scroll]
 
 type flexWrap = [#wrap | #nowrap]
@@ -218,6 +220,7 @@ type flexStyle = {
   columnGap?: size,
   direction?: direction,
   display?: display,
+  boxSizing?: boxSizing,
   end?: size,
   flex?: float,
   flexBasis?: margin,

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -112,6 +112,8 @@ type blendMode = [
 
 type isolation = [#auto | #isolate]
 
+type outlineStyle = [#solid | #dotted | #dashed]
+
 type resizeMode = [#cover | #contain | #stretch | #repeat | #center]
 
 type fontStyle = [#normal | #italic]
@@ -346,6 +348,10 @@ type viewCoreStyle = {
   isolation?: isolation,
   elevation?: float,
   opacity?: float,
+  outlineColor?: Color.t,
+  outlineOffset?: float,
+  outlineStyle?: outlineStyle,
+  outlineWidth?: float,
 }
 
 // Text Style Props (https://reactnative.dev/docs/text-style-props)

--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -126,7 +126,7 @@ type backfaceVisibility = [#visible | #hidden]
 
 type borderStyle = [#solid | #dotted | #dashed]
 
-type display = [#none | #flex]
+type display = [#none | #flex | #contents]
 
 type overflow = [#visible | #hidden | #scroll]
 


### PR DESCRIPTION
- add `display: contents` style _(only work with new architecture)_
- add `mixBlendMode` and `isolation` styles _(only work with new architecture)_
- add `boxSizing` style _(only work with new architecture)_
- add `outlineColor`, `outlineOffset`, `outlineStyle` and `outlineWidth` styles _(only work with new architecture)_