### PR TITLE
Use record for separatorComponentProps

### DIFF
--- a/src/components/VirtualizedList.res
+++ b/src/components/VirtualizedList.res
@@ -40,7 +40,7 @@ type onScrollToIndexFailedParams = {
   averageItemLength: float,
 }
 
-type separatorComponentProps<'item> = {"highlighted": bool, "leadingItem": option<'item>}
+type separatorComponentProps<'item> = {highlighted: bool, leadingItem: option<'item>}
 
 type viewabilityConfig = {
   minimumViewTime?: float,


### PR DESCRIPTION
So that it actually becomes possible to pass a matching JSX v4 component declared with

```rescript
@react.component(: VirtualizedList.separatorComponentProps<'item>)
let make = ...
```